### PR TITLE
Fix package description typo

### DIFF
--- a/zprint-format.el
+++ b/zprint-format.el
@@ -1,4 +1,4 @@
-;;; zprint-format.el --- Reformatter Clojure code using zprint -*- lexical-binding: t -*-
+;;; zprint-format.el --- Reformat Clojure code using zprint -*- lexical-binding: t -*-
 
 ;; Copyright © 2021 Derek Passen
 


### PR DESCRIPTION
I think you missed out "for", but this is clearer still IMO. :-)

(In connection with https://github.com/melpa/melpa/pull/7595)